### PR TITLE
use async accept, read, write to handle multiple clients

### DIFF
--- a/src/client.cpp
+++ b/src/client.cpp
@@ -12,12 +12,12 @@ void send(std::string const &command, asio::ip::tcp::socket &socket) {
 }
 
 int main(int argc, char **argv) {
-  // open up a connection to the server
   asio::io_context io_context;
   asio::ip::tcp::socket socket(io_context);
+  unsigned short port = (argc >= 2) ? std::atoi(argv[1]) : 6969;
 
   try {
-    asio::ip::tcp::endpoint endpoint(asio::ip::address::from_string("127.0.0.1"), 5433);
+    asio::ip::tcp::endpoint endpoint(asio::ip::address::from_string("127.0.0.1"), port);
     socket.connect(endpoint);
 
     // listen for user input

--- a/src/database.cpp
+++ b/src/database.cpp
@@ -4,14 +4,14 @@
 #include "database.h"
 #include <future>
 
-std::unordered_map<std::string, std::string> records;
+std::unordered_map<std::string, std::string> records_;
 
 Database::Database() : DATABASE_FILENAME("../database.txt") {
   std::ifstream db = openDbForReading();
   Record record;
 
   while (db >> record.key >> record.value) {
-    records[record.key] = record.value;
+    records_[record.key] = record.value;
   }
 
   db.close();
@@ -23,14 +23,14 @@ std::string Database::all() {
   Record record;
 
   std::string output = "";
-  for (const auto &pair : records) {
+  for (const auto &pair : records_) {
     record.key = pair.first;
     record.value = pair.second;
     output.append(record.toString());
   }
 
   output.append("----\n");
-  output.append(std::to_string(records.size()));
+  output.append(std::to_string(records_.size()));
 
   return output;
 }
@@ -40,7 +40,7 @@ std::string Database::find(const std::string& key) {
   record.key = key;
 
   try {
-    record.value = records.at(key);
+    record.value = records_.at(key);
   } catch (const std::out_of_range &e) {
     std::ifstream db = openDbForReading();
     bool found = false;
@@ -55,7 +55,7 @@ std::string Database::find(const std::string& key) {
     db.close();
 
     if (!found) throw std::runtime_error("error: record not found");
-    records[key] = record.value;
+    records_[key] = record.value;
   }
 
   return record.value;
@@ -79,7 +79,7 @@ std::string Database::insert(const std::string &key, const std::string &value) {
 
   std::async([this, newRecord]() { writeRecordToFile(newRecord); });
 
-  records[key] = value;
+  records_[key] = value;
 
   return "INSERT";
 }
@@ -117,7 +117,7 @@ std::string Database::remove(const std::string& key) {
     return "error: record not found";
   }
 
-  records.erase(key);
+  records_.erase(key);
 
   std::async([this, key]() { removeRecordFromFile(key); });
 
@@ -160,7 +160,7 @@ std::string Database::update(const std::string& key, const std::string& value) {
   }
 
   std::async([this, key, value]() { updateRecordInFile(key, value); });
-  records[key] = value;
+  records_[key] = value;
 
   return "UPDATE";
 }

--- a/src/database.cpp
+++ b/src/database.cpp
@@ -6,7 +6,7 @@
 
 std::unordered_map<std::string, std::string> records_;
 
-Database::Database() : DATABASE_FILENAME("../database.txt") {
+Database::Database() : DATABASE_FILENAME_("../database.txt") {
   std::ifstream db = openDbForReading();
   Record record;
 
@@ -106,8 +106,8 @@ void Database::removeRecordFromFile(const std::string& key) {
     throw std::runtime_error("error: could not remove record");
   }
 
-  std::remove(DATABASE_FILENAME.c_str());
-  std::rename("temp.txt", DATABASE_FILENAME.c_str());
+  std::remove(DATABASE_FILENAME_.c_str());
+  std::rename("temp.txt", DATABASE_FILENAME_.c_str());
 }
 
 std::string Database::remove(const std::string& key) {
@@ -120,8 +120,6 @@ std::string Database::remove(const std::string& key) {
   records_.erase(key);
 
   std::async([this, key]() { removeRecordFromFile(key); });
-
-  std::cout << "after async" << std::endl;
 
   return "REMOVE";
 }
@@ -148,8 +146,8 @@ void Database::updateRecordInFile(const std::string& key, const std::string& val
     throw std::runtime_error("error: could not update record");
   }
 
-  std::remove(DATABASE_FILENAME.c_str());
-  std::rename("temp.txt", DATABASE_FILENAME.c_str());
+  std::remove(DATABASE_FILENAME_.c_str());
+  std::rename("temp.txt", DATABASE_FILENAME_.c_str());
 }
 
 std::string Database::update(const std::string& key, const std::string& value) {
@@ -184,9 +182,9 @@ std::ofstream Database::openFileForWriting(const std::string& filename) {
 }
 
 std::ifstream Database::openDbForReading() {
-  return openFileForReading(DATABASE_FILENAME);
+  return openFileForReading(DATABASE_FILENAME_);
 }
 
 std::ofstream Database::openDbForWriting() {
-  return openFileForWriting(DATABASE_FILENAME);
+  return openFileForWriting(DATABASE_FILENAME_);
 }

--- a/src/database.h
+++ b/src/database.h
@@ -8,7 +8,6 @@
 
 class Database {
 public:
-  const std::string DATABASE_FILENAME;
   Database();
   ~Database();
   std::string insert(const std::string &key, const std::string &value);
@@ -17,6 +16,7 @@ public:
   std::string remove(const std::string &key);
   std::string update(const std::string &key, const std::string &value);
 private:
+  const std::string DATABASE_FILENAME_;
   struct Record {
     std::string key;
     std::string value;

--- a/src/database.h
+++ b/src/database.h
@@ -25,7 +25,7 @@ private:
       return key + " " + value + "\n";
     }
   };
-  std::unordered_map<std::string, std::string> records;
+  std::unordered_map<std::string, std::string> records_;
   void writeRecordToFile(const Record &record);
   void updateRecordInFile(const std::string& key, const std::string& value);
   void removeRecordFromFile(const std::string& key);

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -4,98 +4,153 @@
 #include <asio.hpp>
 #include "database.h"
 #include <boost/algorithm/string.hpp>
+#include <cstdlib>
+#include <memory>
+#include <utility>
+
+using asio::ip::tcp;
+
+// database is global
+Database db;
+
+std::vector<std::string> parseCommandArgs(const std::string& command) {
+  std::istringstream iss(command);
+  std::string str;
+  std::vector<std::string> args;
+
+  while (getline(iss, str, ' ')) {
+    args.push_back(str);
+  }
+
+  return args;
+}
+
+std::string executeCommand(const std::vector<std::string>& args) {
+  if (boost::iequals(args[0], "ALL")) {
+    return db.all();
+  }
+  if (boost::iequals(args[0], "INSERT")) {
+    if (args.size() != 3) throw std::runtime_error("error: INSERT requires 2 arguments");
+    return db.insert(args[1], args[2]);
+  }
+  if (boost::iequals(args[0], "FIND")) {
+    if (args.size() != 2) throw std::runtime_error("error: FIND requires 1 argument");
+    return db.find(args[1]);
+  }
+  if (boost::iequals(args[0], "REMOVE")) {
+    if (args.size() != 2) throw std::runtime_error("error: REMOVE requires 1 argument");
+    return db.remove(args[1]);
+  }
+  if (boost::iequals(args[0], "UPDATE")) {
+    if (args.size() != 3) throw std::runtime_error("error: UPDATE requires 2 arguments");
+    return db.update(args[1], args[2]);
+  }
+
+  return "error: invalid command";
+}
+
+class Session : public std::enable_shared_from_this<Session> {
+public:
+  Session(tcp::socket socket, int id) : socket_(std::move(socket)), id_(id) {
+    ip_ = socket_.remote_endpoint().address().to_string();
+    std::cout << "Client " << idStr() << " connected from " << ip_ << "\n";
+  }
+
+  ~Session() {
+    std::cout << "Client " << idStr() << " disconnected" << "\n";
+  }
+
+  void start() {
+    read();
+  }
+
+private:
+  tcp::socket socket_;
+  std::string ip_;
+  int id_;
+  enum { max_length = 1024 };
+  char data_[max_length];
+
+  void read() {
+    auto self(shared_from_this());
+
+    socket_.async_read_some(asio::buffer(data_, max_length),
+        [this, self](std::error_code ec, std::size_t length) {
+          if (!ec) {
+            try {
+              if (length == 0) throw std::runtime_error("no bytes read");
+              std::string command(data_, length);
+
+              std::cout << idStr() << ": " << command << std::endl;
+
+              std::vector<std::string> args = parseCommandArgs(command);
+              std::string response = executeCommand(args);
+
+              write(response.c_str());
+            } catch (const std::exception &e) {
+              // respond with error message
+              write(e.what());
+            }
+          }
+        });
+  }
+
+  void write(const char *response) {
+    auto self(shared_from_this());
+
+    std::size_t length = strlen(response);
+    std::memcpy(data_, response, length);
+
+    asio::async_write(socket_, asio::buffer(data_, length),
+        [this, self](std::error_code ec, std::size_t /*length*/) {
+          if (!ec) {
+            read();
+          }
+        });
+  }
+
+  std::string idStr() {
+    return std::to_string(id_);
+  }
+};
+
 
 class Server {
   public:
     Server(asio::io_context& io_context, unsigned short port)
-      : io_context(io_context),
-        acceptor(io_context, asio::ip::tcp::endpoint(asio::ip::tcp::v4(), port)) {
+      : acceptor_(io_context, tcp::endpoint(tcp::v4(), port)) {
       std::cout << "smalltable server listening on port " << port << std::endl;
-    }
-
-    void start() {
-      while (true) {
-        try {
-          asio::ip::tcp::socket socket(io_context);
-          acceptor.accept(socket);
-          std::string ip = socket.remote_endpoint().address().to_string();
-
-          std::cout << ip << " connected" << std::endl;
-
-          while (true) {
-            char data[1024];
-
-            try {
-              std::size_t bytes_read = socket.read_some(asio::buffer(data, sizeof(data)));
-
-              if (bytes_read == 0) throw std::runtime_error("no bytes read");
-
-              std::cout << ip << ": " << data << std::endl;
-
-              std::vector<std::string> args = parseArgs(data);
-              std::string response = executeCommand(args);
-
-              asio::write(socket, asio::buffer(response));
-            } catch (const std::exception &e) {
-              // respond with error message
-              asio::write(socket, asio::buffer(std::string(e.what())));
-            }
-
-            // clear buffer
-            memset(data, 0, 1024);
-          }
-        } catch (const std::exception &e) {
-          std::cerr << "client disconnected - " << e.what() << std::endl;
-        }
-      }
+      accept();
     }
 
   private:
-    asio::io_context &io_context;
-    asio::ip::tcp::acceptor acceptor;
-    Database db;
+    tcp::acceptor acceptor_;
+    int nextId_ = 0;
 
-    std::vector<std::string> parseArgs(const std::string& command) {
-      std::istringstream iss(command);
-      std::string str;
-      std::vector<std::string> args;
+    void accept() {
+      acceptor_.async_accept(
+          [this](std::error_code ec, tcp::socket socket) {
+            if (!ec) {
+              std::make_shared<Session>(std::move(socket), nextId_++)->start();
+            }
 
-      while (getline(iss, str, ' ')) {
-        args.push_back(str);
-      }
-
-      return args;
-    }
-
-    std::string executeCommand(const std::vector<std::string>& args) {
-      std::string response;
-
-      if (boost::iequals(args[0], "ALL")) {
-        response = db.all();
-      } else if (boost::iequals(args[0], "INSERT")) {
-        if (args.size() != 3) throw std::runtime_error("error: INSERT requires 2 arguments");
-        response = db.insert(args[1], args[2]);
-      } else if (boost::iequals(args[0], "FIND")) {
-        if (args.size() != 2) throw std::runtime_error("error: FIND requires 1 argument");
-        response = db.find(args[1]);
-      } else if (boost::iequals(args[0], "REMOVE")) {
-        if (args.size() != 2) throw std::runtime_error("error: REMOVE requires 1 argument");
-        response = db.remove(args[1]);
-      } else if (boost::iequals(args[0], "UPDATE")) {
-        if (args.size() != 3) throw std::runtime_error("error: UPDATE requires 2 arguments");
-        response = db.update(args[1], args[2]);
-      } else {
-        response = "error: invalid command";
-      }
-
-      return response;
+            accept();
+          });
     }
 };
 
-int main() {
-  asio::io_context io_context;
-  Server server(io_context, 5433);
-  server.start();
+int main(int argc, char* argv[]) {
+  try {
+    asio::io_context io_context;
+    unsigned short port = (argc >= 2) ? std::atoi(argv[1]) : 6969;
+
+    Server server(io_context, port);
+
+    io_context.run();
+  } catch (std::exception& e) {
+    std::cerr << "error in main: " << e.what() << "\n";
+    return 1;
+  }
 
   return 0;
 }

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -49,6 +49,7 @@ std::string executeCommand(const std::vector<std::string>& args) {
   return "error: invalid command";
 }
 
+// https://think-async.com/Asio/asio-1.28.0/src/examples/cpp11/echo/async_tcp_echo_server.cpp
 class Session : public std::enable_shared_from_this<Session> {
 public:
   Session(tcp::socket socket, int id) : socket_(std::move(socket)), id_(id) {


### PR DESCRIPTION
some refactoring too.

- Limits responsibility of server to strictly accepting connections and spinning up a new session for them, delegating the reading/writing/executing to the session.
- Adds port as optional argument for server/client
- I like the idea of using `_` for instance/member variables. When used in methods it indicates their scope is broader than just that method, like @ in ruby. So I changed all of them to have underscores :)